### PR TITLE
cad-pulse.c: fix port availability detection

### DIFF
--- a/src/cad-pulse.c
+++ b/src/cad-pulse.c
@@ -577,6 +577,15 @@ static void init_card_info(pa_context *ctx, const pa_card_info *info, int eol, v
     for (i = 0; i < info->n_ports; i++) {
         pa_card_port_info *port = info->ports[i];
 
+#ifdef WITH_DROID_SUPPORT
+        if (strstr(port->name, DROID_OUTPUT_PORT_SPEAKER) != NULL) {
+            has_speaker = TRUE;
+        } else if (strstr(port->name, DROID_OUTPUT_PORT_EARPIECE) != NULL ||
+                   strstr(port->name, DROID_OUTPUT_PORT_WIRED_HEADSET)  != NULL) {
+            has_earpiece = TRUE;
+        }
+    }
+#else
         if (strstr(port->name, SND_USE_CASE_DEV_SPEAKER) != NULL) {
             has_speaker = TRUE;
         } else if (strstr(port->name, SND_USE_CASE_DEV_EARPIECE) != NULL ||
@@ -584,6 +593,7 @@ static void init_card_info(pa_context *ctx, const pa_card_info *info, int eol, v
             has_earpiece = TRUE;
         }
     }
+#endif
 
     if (!has_speaker || !has_earpiece) {
         g_message("Card '%s' lacks speaker and/or earpiece port, skipping...",


### PR DESCRIPTION
This commits fixes the port name checks so `callaudiod` can check if speaker/wired and input are available