### PR TITLE
cad-manager: Only switch CallAudioMode if new value is different.

### DIFF
--- a/src/cad-manager.c
+++ b/src/cad-manager.c
@@ -81,8 +81,11 @@ static gboolean cad_manager_handle_select_mode(CallAudioDbusCallAudio *object,
     op->invocation = invocation;
     op->callback = complete_command_cb;
 
-    g_debug("Select mode: %u", mode);
-    cad_pulse_select_mode(mode, op);
+    CallAudioMode currentMode = cad_pulse_get_audio_mode();
+    if(currentMode != mode){
+        g_debug("Change mode from '%u', to '%u'",currentMode, mode);
+        cad_pulse_select_mode(mode, op);
+    }
 
     return TRUE;
 }


### PR DESCRIPTION
This fixes not switching back to speaker after ending a call on Thinkphone, or it actually did. A second call to set CallAudioMode to something whats already set was selecting the earpeace as output.

This should not affect any other devices or API versions. But to confirm need to test it. I've tested now for 3 weeks on Thinkphone with API32/API33